### PR TITLE
Add CrossStorage access for OF authentication

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 	<link type="text/css" rel="stylesheet" href="build/glslEditor.css">
     <script type="text/javascript" src="build/glslEditor.js"></script>
     <script type="text/javascript">
-    	window.glslEditor = new GlslEditor('#glsl_editor', { 
+    	window.glslEditor = new GlslEditor('#glsl_editor', {
     		canvas_size: 500,
             canvas_draggable: true,
             canvas_resizable: true,
@@ -33,7 +33,7 @@
             fileDrops: true,
     		menu: true
     	});
-        document.body.style.backgroundColor = window.getComputedStyle(glslEditor.editor.getWrapperElement(),null).getPropertyValue('background-color'); 
+        document.body.style.backgroundColor = window.getComputedStyle(glslEditor.editor.getWrapperElement(),null).getPropertyValue('background-color');
     </script>
     <script>
         (function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "babel-runtime": "5.8.29",
     "codemirror": "5.8.0",
     "document-register-element": "^1.3.0",
+    "cross-storage": "^1.0.0",
     "glslCanvas": "^0.0.17",
     "xhr": "^2.2.0"
   },

--- a/src/js/GlslEditor.js
+++ b/src/js/GlslEditor.js
@@ -21,8 +21,12 @@ import { subscribeMixin } from './tools/mixin';
 // 3er Parties
 import { saveAs } from './vendor/FileSaver.min.js';
 
-const EMPTY_FRAG_SHADER = `// Author: 
-// Title: 
+// Cross storage for Openframe -- allows restricted access to certain localStorage operations
+// on the openframe domain
+import { CrossStorageClient } from 'cross-storage';
+
+const EMPTY_FRAG_SHADER = `// Author:
+// Title:
 
 #ifdef GL_ES
 precision mediump float;
@@ -188,13 +192,20 @@ export default class GlslEditor {
             else {
                 this.new();
             }
-        } 
+        }
         else {
             this.new();
         }
-        
+
+        // setup CrossStorage client
+        this.storage = new CrossStorageClient('https://openframe.io/hub.html');
+        this.storage.onConnect().then(() => {
+        }.bind(this));
+
         return this;
     }
+
+
 
     new () {
         this.setContent(this.options.frag || EMPTY_FRAG_SHADER, (new Date().getTime()).toString());
@@ -290,6 +301,11 @@ export default class GlslEditor {
         else {
             return 'unknown';
         }
+    }
+
+    // Returns Promise
+    getOfToken() {
+        return this.storage.get('accessToken');
     }
 
     download () {


### PR DESCRIPTION
This updates the way the editor authenticates with the Openframe server. We're making things a bit more secure, but still aren't using OAuth, so we use [CrossStorage](https://github.com/zendesk/cross-storage) to give specified domains access to certain localStorage functionality.

@patriciogonzalezvivo As mentioned a few weeks back, please don't merge this in until we've been in touch regarding the Openframe release. Hoping to get that out early this week (finally!!), at which point this will need to be merged so that people can still export directly to Openframe.

