### PR TITLE
throw error when element not found

### DIFF
--- a/src/js/GlslEditor.js
+++ b/src/js/GlslEditor.js
@@ -56,6 +56,9 @@ export default class GlslEditor {
         }
         else if (typeof selector === 'string') {
             this.container = document.querySelector(selector);
+            if (!this.container) {
+                throw new Error(`element ${selector} not present`);
+            }
         }
         else {
             console.log('Error, type ' + typeof selector + ' of ' + selector + ' is unknown');


### PR DESCRIPTION
This bit me a few times doing some other refactoring. Saves digging for the reason of  'undefined is not a function' later on in the constructor.