### PR TITLE
fix some errors reported when touching the canvas

### DIFF
--- a/src/js/tools/interactiveDom.js
+++ b/src/js/tools/interactiveDom.js
@@ -48,9 +48,9 @@ export function subscribeInteractiveDom (dom, options) {
     }
 
     // Mouse events
-    dom.addEventListener('mousedown', onDown);
-    document.addEventListener('mousemove', onMove);
-    document.addEventListener('mouseup', onUp);
+    dom.addEventListener('mousedown', onMouseDown);
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
 
     // Touch events
     dom.addEventListener('touchstart', onTouchDown, { passive: false });
@@ -84,6 +84,24 @@ export function subscribeInteractiveDom (dom, options) {
         if (event.touches.length === 0) {
             onUp(event.changedTouches[0]);
         }
+    }
+
+    function onMouseDown (event) {
+        event.preventDefault();
+        event.stopPropagation();
+        onDown(event);
+    }
+
+    function onMouseMove (event) {
+        event.preventDefault();
+        event.stopPropagation();
+        onMove(event);
+    }
+
+    function onMouseUp (event) {
+        event.preventDefault();
+        event.stopPropagation();
+        onUp(event);
     }
 
     function onDown (event) {

--- a/src/js/tools/interactiveDom.js
+++ b/src/js/tools/interactiveDom.js
@@ -48,14 +48,14 @@ export function subscribeInteractiveDom (dom, options) {
     }
 
     // Mouse events
-    dom.addEventListener('mousedown', onMouseDown);
+    dom.addEventListener('mousedown', onDown);
     document.addEventListener('mousemove', onMove);
     document.addEventListener('mouseup', onUp);
 
     // Touch events
-    dom.addEventListener('touchstart', onTouchDown);
-    document.addEventListener('touchmove', onTouchMove);
-    document.addEventListener('touchend', onTouchEnd);
+    dom.addEventListener('touchstart', onTouchDown, { passive: false });
+    document.addEventListener('touchmove', onTouchMove, { passive: false });
+    document.addEventListener('touchend', onTouchEnd, { passive: false });
 
     function hintHide() {
         setBounds(ghostdom, b.left, b.top, b.width, b.height);
@@ -63,25 +63,27 @@ export function subscribeInteractiveDom (dom, options) {
     }
 
     function onTouchDown (event) {
-        onDown(event.touches[0]);
-        e.preventDefault();
+        event.preventDefault();
+        event.stopPropagation();
+        if (event.touches.length === 1) {
+            onDown(event.changedTouches[0]);
+        }
     }
 
     function onTouchMove (event) {
         event.preventDefault();
         event.stopPropagation();
-        onMove(event.touches[0]);
-    }
-
-    function onTouchEnd (event) {
-        if (event.touches.length === 0) {
-            onUp(e.changedTouches[0]);
+        if (event.touches.length === 1) {
+            onMove(event.changedTouches[0]);
         }
     }
 
-    function onMouseDown (event) {
-        onDown(event);
-        e.preventDefault();
+    function onTouchEnd (event) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (event.touches.length === 0) {
+            onUp(event.changedTouches[0]);
+        }
     }
 
     function onDown (event) {


### PR DESCRIPTION
Fix some errors reported when touching the canvas @patriciogonzalezvivo 

- I found that console reports very many errors when moving the canvas with a touch screen device.
- When touching to move the canvas or zooming it, the codemirror behind the canvas will also move with it

```
[Intervention]Unable to preventDefault inside passive event listener due to target being treated as passive. 
See https://www.chromestatus.com/feature/5093566007214080
```

```
Uncaught TypeError: Cannot read properties of undefined (reading 'preventDefault')
    at HTMLDivElement.onTouchDown (interactiveDom.js:67:11)
onTouchDown @ interactiveDom.js:67
```

Probably because interactiveDom.js is too old and some web interfaces have changed, causing a series of problems. So I made a small change to it and now

- it doesn't report errors anymore
- The canvas can be moved and scaled normally
- It works fine with `preventDefault`

After my test, using the mouse and touch can work properly :)